### PR TITLE
Freeze Questions by default after instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.0.4] - 2017-03-10
+
+Defaults to freezing Questions after initialization, to prevent concerns with mutating data inadvertently when working with questions as value objects.
+
 ## [0.0.3] - 2017-03-10
 
 Bugfixes for Question#type. Adds minimal error propagation in event Typeform's 

--- a/lib/typed_form/form_response.rb
+++ b/lib/typed_form/form_response.rb
@@ -45,7 +45,7 @@ module TypedForm
           ids: grouped_questions.map(&:id),
           field_id: field_id,
           original_text: question_for_grouped(grouped_questions)
-        )
+        ).freeze
       end
     end
   end

--- a/lib/typed_form/question.rb
+++ b/lib/typed_form/question.rb
@@ -28,7 +28,7 @@ module TypedForm
       question.dup.tap do |new_question|
         new_question.answer = answer
         new_question.text = text
-      end
+      end.freeze
     end
 
     private

--- a/lib/typed_form/version.rb
+++ b/lib/typed_form/version.rb
@@ -1,3 +1,3 @@
 module TypedForm
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Defaults to freezing Questions after initialization, to prevent concerns
with mutating data inadvertently when working with questions as value objects.