### PR TITLE
Add VirtualModel error handling for response_attrs

### DIFF
--- a/spec/virtual_model_spec.rb
+++ b/spec/virtual_model_spec.rb
@@ -105,5 +105,14 @@ RSpec.describe TypedForm::VirtualModel do
         expect{model.submitted_at}.to raise_error(NoMethodError)
       end
     end
+
+    context "attribute is incorrectly referenced" do
+      it "should raise a ArgumentError" do
+        submitted_attr = { "submitted_at" => "metadata.date_submitted" }
+        model = build_model(form: form, response_attrs: submitted_attr)
+        expect{model.submitted_at}
+          .to raise_error(ArgumentError, /date_submitted is not a valid/)
+      end
+    end
   end
 end


### PR DESCRIPTION
When an incorrect response field is entered, the previous error would result
in a "NoMethodError" on the Arendelle object. This adds friendlier error
messages to help spot errors more easily, and additionally whitelists allowable
fields based on whether they are defined as singleton methods on the
TypedForm response object.