### PR TITLE
Add compatability for Arendelle 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+### [0.1.5] - 2017-03-20
+
+Update Arendelle.
+
+Arendelle 0.1.1 introduced a change in their naming of instance
+variables in order to support ivars that start with numbers. This
+updates the ivar behavior (which relies on a private implementation
+detail to handle Typeform's bizarre multiple choice question format).
+
 ### [0.1.4] - 2017-03-16
 
 Strips additional whitespace and isolates whitespace stripping behavior to a Util class, to allow for easier test coverage. Adds raw_json accessors to models where we normalize JSON input to allow for end-users to determine whether they want clean/normalized JSON or the original results from Typeform. This prevents mismatches in the regular expression => attribute matching in VirtualModel, which were running into issues when `" " != " "`, preventing the regular expressions from matching.

--- a/lib/typed_form/form_data/answers.rb
+++ b/lib/typed_form/form_data/answers.rb
@@ -87,7 +87,7 @@ module TypedForm
       end
 
       def find_answer_by_id(id)
-        answers.instance_variable_get("@#{id}")
+        answers.instance_variable_get("@_#{id}")
       end
 
       def form_duplicated_on_typeform?

--- a/lib/typed_form/version.rb
+++ b/lib/typed_form/version.rb
@@ -1,4 +1,4 @@
 module TypedForm
   # Up-to-date version of gem.
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
Arendelle 0.1.1 introduced a change in their naming of instance
variables in order to support ivars that start with numbers. This
updates the ivar behavior (which relies on a private implementation
detail to handle Typeform's bizarre multiple choice question format).