### PR TITLE
Strip hex-formatted non-breaking UTF-8 spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### [0.1.7] - 2017-08-10
+
+Fixes issues interpreting `\xC2\xA0` by replacing it with a standard space (alternate representation of `\u00a0` initially removed in 0.1.2).
+
 ### [0.1.6] - 2017-03-22
 
 Fixes NoMethodError: undefined method `[]' for nil:NilClass error when normalizing optional date fields that are left blank (which translates to nil in Typeform Data).

--- a/lib/typed_form/util.rb
+++ b/lib/typed_form/util.rb
@@ -4,7 +4,7 @@ module TypedForm
     # Removes non-breaking spaces (character point 160) from TypeForm data
     # before beginning processing.
     def self.normalize_spaces(text)
-      text.gsub("\\u00a0", " ").gsub(/[[:space:]]/, " ")
+      text.gsub(/(\\u00a0|\\xC2\\xA0)/, " ").gsub(/[[:space:]]/, " ")
     end
   end
 end

--- a/spec/fixtures/data_api/single_form_response.json
+++ b/spec/fixtures/data_api/single_form_response.json
@@ -134,7 +134,7 @@
     },
     {
       "id": "list_fprR_choice",
-      "question": "Does\u00a0{{answer_44763783}} have an advisor (coach, department head, etc)?",
+      "question": "Does\xC2\xA0{{answer_44763783}} have an advisor (coach, department head, etc)?",
       "field_id": 44763793,
       "group": "group_45395775"
     },


### PR DESCRIPTION
Typeform recently began sending an additional representation
of breaking space (hex-formatted). This adds it to the list
of characters in the space normalizing regex, replacing
it with a normal space.

Adds \xC2\xA0 in the single form example JSON, to ensure
that normalization is working on both sets of possible spaces.